### PR TITLE
RRset duplicates are taken into account not to confuse dns-api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Example `gcore.ini` file:
 ```ini
 # G-Core API urls used by Certbot
 dns_gcore_api_url = https://api.reseller.com
-# implies that authapi available as / and dnsapi as /dns
+# implies that authapi available as /iam and dnsapi as /dns
 
 # or
-dns_gcore_auth_url = https://authapi.example.com
+dns_gcore_auth_url = https://api.example.org/iam
 dns_gcore_dns_api_url = https://dnsapi.example.com
 ```
 

--- a/certbot_dns_gcore/api_gcore.py
+++ b/certbot_dns_gcore/api_gcore.py
@@ -29,7 +29,7 @@ class GCoreClient:
 
     _root_zones = 'v2/zones'
     _dns_api_url = 'https://api.gcorelabs.com/dns'
-    _auth_url = 'https://api.gcorelabs.com'
+    _auth_url = 'https://api.gcorelabs.com/iam'
     _timeout = 10.0
     _error_format = 'Error. %s: %r, data: "%r", response: %s'
 
@@ -43,7 +43,7 @@ class GCoreClient:
         else:
             raise ValueError('either token or login & password must be set')
         if api_url:
-            self._auth_url = api_url
+            self._auth_url = self._build_url(api_url, '/iam')
             self._dns_api_url = self._build_url(api_url, '/dns')
             # more specific parameters should win thus go latter
         if dns_api_url:

--- a/certbot_dns_gcore/api_gcore.py
+++ b/certbot_dns_gcore/api_gcore.py
@@ -31,7 +31,7 @@ class GCoreClient:
     _dns_api_url = 'https://api.gcorelabs.com/dns'
     _auth_url = 'https://api.gcorelabs.com/iam'
     _timeout = 10.0
-    _error_format = 'Error. %s: %r, data: "%r", response: %s'
+    _error_format = 'Error %s. %s: %r, data: "%r", response: %s'
 
     def __init__(self, token=None, login=None, password=None, api_url=None, dns_api_url=None, auth_url=None):
         self._session = Session()
@@ -67,12 +67,14 @@ class GCoreClient:
         if responce.status_code in (  # pylint: disable=R1720
                 http.HTTPStatus.BAD_REQUEST, http.HTTPStatus.INTERNAL_SERVER_ERROR,
         ):
-            logger.error(self._error_format, method, url, data or params, responce.text)
+            logger.error(self._error_format, responce.status_code, method, url, data or params, responce.text)
             raise GCoreException(responce.text)
         elif responce.status_code == http.HTTPStatus.CONFLICT:
-            raise GCoreConflictException(self._error_format % (method, url, data or params, responce.text))
+            raise GCoreConflictException(self._error_format % (responce.status_code, method, url,
+                                                               data or params, responce.text))
         elif responce.status_code == http.HTTPStatus.NOT_FOUND:
-            raise GCoreNotFoundException(self._error_format % (method, url, data or params, responce.text))
+            raise GCoreNotFoundException(self._error_format % (responce.status_code, method, url,
+                                                               data or params, responce.text))
         responce.raise_for_status()
         return responce
 

--- a/certbot_dns_gcore/dns_gcore.py
+++ b/certbot_dns_gcore/dns_gcore.py
@@ -136,7 +136,8 @@ class _GCoreClient:
         except GCoreConflictException:
             logger.debug('Record already present on zone. Try to update record content')
             exist_record_content = self.gcore.record_content(domain, record_name, self.record_type)
-            exist_record_content.append(record_content)
+            if record_content not in exist_record_content:
+                exist_record_content.append(record_content)
             self.gcore.record_update(
                 domain,
                 record_name,


### PR DESCRIPTION
Should fix for the following case:

```
Renewing an existing certificate for *.preprod.be
Unsafe permissions on credentials configuration file: ./creds
Error. PUT: 'https://api.preprod.world/dns/v2/zones/preprod.be/_acme-challenge.preprod.be/TXT', data: "{'resource_records': [{'content': ['xTykygpQ7cFLC_t7MbU1UP6DdH5-D2xTrwRK40STEYY'], 'enabled': True}, {'content': ['xTykygpQ7cFLC_t7MbU1UP6DdH5-D2xTrwRK40STEYY'], 'enabled': True}], 'ttl': 300}", response: {"error":"two or more records have same content"}

Failed to renew certificate preprod.be with error: {"error":"two or more records have same content"}
```